### PR TITLE
Fix component order of exported seismograms

### DIFF
--- a/SplitLab1.9.0/config_GUI/seisFigButtons.m
+++ b/SplitLab1.9.0/config_GUI/seisFigButtons.m
@@ -243,12 +243,12 @@ Amp    = Amp(:,window);
 time   = time(window);
 
 
-if thiseq.system=='ENV'
-    cname ='ENZ';
+if strcmp(thiseq.system,'ENV')
+    cname = 'ENZ';
     cmpinc = [90  90   0];
     cmpaz  = [0   90  90];
-elseif thiseq.system=='LTQ'
-    cname ='LTQ';
+elseif strcmp(thiseq.system,'LTQ')
+    cname = 'QTL';
     cmpinc = [-12345.0 -12345.0 -12345.0];
     cmpaz  = [-12345.0 -12345.0 -12345.0];
 end


### PR DESCRIPTION
This PR fixes an error in the order of the L, Q, T components when saving the traces which are currently displayed in the Seismogram Viewer as new SAC files  by the _SplitLab_ function `~\SplitLab\config_GUI\seisFigButtons.m`.

 The export order of the traces is based on the display order in the Seismogram Viewer. For the ray coordinate system this is `Q T L` (top to bottom).  However, the string used and split into single characters to set SAC header and file name is `cname = 'LTQ'` (left to right).  This leads to mixed up L and Q components of the exported traces. To avoid this `cname` was changed to `cname = 'QTL'`.